### PR TITLE
Add Firestore rules guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,27 @@ Na tela de designações há um botão **Gerir Saídas**. Nele é possível cada
 uma grade semanal de pontos de encontro do serviço de campo, além de manter as
 listas de modalidades e locais base. Ao selecionar um mês, as saídas cadastradas
 são carregadas automaticamente; basta designar os dirigentes.
+
+## Firestore security rules
+
+Authenticated users (or specific admin emails) need read and write access to
+Firestore. A minimal example looks like:
+
+```firestore
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if request.auth != null &&
+        request.auth.token.email in ['admin@example.com'];
+    }
+  }
+}
+```
+
+See the [Firebase documentation](https://firebase.google.com/docs/firestore/security/get-started)
+for more details.
+
+When running the emulator, any rules file specified in `firebase.json` will be
+used automatically. If you connect to a real Firebase project, remember to
+deploy or configure your security rules accordingly.


### PR DESCRIPTION
## Summary
- document Firestore security rule requirements
- explain using emulator vs production rules

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684dd24c37cc83338daae9a0d7c9043b