### PR TITLE
Add admin password protection for members area

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ são carregadas automaticamente; basta designar os dirigentes.
 ## Senha Administrativa
 
 Em **Configurações** é possível definir a senha de administrador. Ela será solicitada ao acessar a opção **Gerenciar Membros** no menu lateral.
+A senha fica armazenada no Firestore, sendo compartilhada entre todos os usuários.

--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ Na tela de designações há um botão **Gerir Saídas**. Nele é possível cada
 uma grade semanal de pontos de encontro do serviço de campo, além de manter as
 listas de modalidades e locais base. Ao selecionar um mês, as saídas cadastradas
 são carregadas automaticamente; basta designar os dirigentes.
+
+## Senha Administrativa
+
+Em **Configurações** é possível definir a senha de administrador. Ela será solicitada ao acessar a opção **Gerenciar Membros** no menu lateral.

--- a/src/app/configuracoes/page.tsx
+++ b/src/app/configuracoes/page.tsx
@@ -24,6 +24,8 @@ import { ConfirmClearDialog, type ConfirmClearDialogProps } from '@/components/c
 import type { Membro } from '@/lib/congregacao/types';
 import { Label } from '@/components/ui/label';
 import { NOMES_MESES } from '@/lib/congregacao/constants';
+import { Input } from '@/components/ui/input';
+import { useAdminAuth } from '@/hooks/use-admin-auth';
 
 export default function ConfiguracoesPage() {
   const { toast } = useToast();
@@ -36,6 +38,10 @@ export default function ConfiguracoesPage() {
   const scheduleManagement = useScheduleManagement({ membros, updateMemberHistory: () => {} }); // Pass dummy updateMemberHistory
   const { clearPublicAssignments } = usePublicMeetingAssignments();
   const { scheduleMes, scheduleAno, clearScheduleForMonth } = scheduleManagement;
+
+  const { setPassword } = useAdminAuth();
+  const [pwd, setPwd] = useState('');
+  const [confirmPwd, setConfirmPwd] = useState('');
 
   // State for confirmation dialog
   const [isConfirmClearOpen, setIsConfirmClearOpen] = useState(false);
@@ -59,6 +65,17 @@ export default function ConfiguracoesPage() {
      } else {
          toast({ title: "Erro", description: "Função de limpeza não disponível.", variant: "destructive" });
      }
+  };
+
+  const handleSavePassword = () => {
+    if (!pwd || pwd !== confirmPwd) {
+      toast({ title: 'Erro', description: 'As senhas não conferem.', variant: 'destructive' });
+      return;
+    }
+    setPassword(pwd);
+    setPwd('');
+    setConfirmPwd('');
+    toast({ title: 'Sucesso', description: 'Senha atualizada.' });
   };
 
   return (
@@ -143,6 +160,24 @@ export default function ConfiguracoesPage() {
               Limpar TODOS os Dados
             </Button>
           </div>
+        </CardContent>
+      </Card>
+
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>Senha Administrativa</CardTitle>
+          <CardDescription>Defina a senha necessária para acessar Gerenciar Membros.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <Label htmlFor="admin-pwd">Senha</Label>
+            <Input id="admin-pwd" type="password" value={pwd} onChange={(e) => setPwd(e.target.value)} />
+          </div>
+          <div>
+            <Label htmlFor="admin-pwd-confirm">Confirmar Senha</Label>
+            <Input id="admin-pwd-confirm" type="password" value={confirmPwd} onChange={(e) => setConfirmPwd(e.target.value)} />
+          </div>
+          <Button onClick={handleSavePassword}>Salvar</Button>
         </CardContent>
       </Card>
 

--- a/src/app/configuracoes/page.tsx
+++ b/src/app/configuracoes/page.tsx
@@ -67,12 +67,12 @@ export default function ConfiguracoesPage() {
      }
   };
 
-  const handleSavePassword = () => {
+  const handleSavePassword = async () => {
     if (!pwd || pwd !== confirmPwd) {
       toast({ title: 'Erro', description: 'As senhas não conferem.', variant: 'destructive' });
       return;
     }
-    setPassword(pwd);
+    await setPassword(pwd);
     setPwd('');
     setConfirmPwd('');
     toast({ title: 'Sucesso', description: 'Senha atualizada.' });

--- a/src/app/congregacao/membros/page.tsx
+++ b/src/app/congregacao/membros/page.tsx
@@ -15,6 +15,8 @@ import { MemberManagementCard, type MemberManagementCardProps } from '@/componen
 import { MemberFormDialog } from '@/components/congregacao/MemberFormDialog';
 import { BulkAddDialog } from '@/components/congregacao/BulkAddDialog';
 import { ConfirmClearDialog, type ConfirmClearDialogProps } from '@/components/congregacao/ConfirmClearDialog';
+import { AdminPasswordDialog } from '@/components/congregacao/AdminPasswordDialog';
+import { useAdminAuth } from '@/hooks/use-admin-auth';
 // Removed SubstitutionDialog import
 // import { SubstitutionDialog } from '@/components/congregacao/SubstitutionDialog';
 // Removed CongregationIcon import
@@ -49,6 +51,18 @@ import { Users, History, Trash2 } from 'lucide-react'; // Assuming these are use
 
 
 const MemberManagementPage = () => {
+  const { authenticated } = useAdminAuth();
+  const [pwdOpen, setPwdOpen] = useState(!authenticated);
+
+  if (!authenticated) {
+    return (
+      <AdminPasswordDialog
+        isOpen={pwdOpen}
+        onOpenChange={setPwdOpen}
+        onSuccess={() => setPwdOpen(false)}
+      />
+    );
+  }
   const {
     membros,
     isMemberFormOpen,

--- a/src/app/congregacao/membros/page.tsx
+++ b/src/app/congregacao/membros/page.tsx
@@ -53,16 +53,6 @@ import { Users, History, Trash2 } from 'lucide-react'; // Assuming these are use
 const MemberManagementPage = () => {
   const { authenticated } = useAdminAuth();
   const [pwdOpen, setPwdOpen] = useState(!authenticated);
-
-  if (!authenticated) {
-    return (
-      <AdminPasswordDialog
-        isOpen={pwdOpen}
-        onOpenChange={setPwdOpen}
-        onSuccess={() => setPwdOpen(false)}
-      />
-    );
-  }
   const {
     membros,
     isMemberFormOpen,
@@ -80,6 +70,16 @@ const MemberManagementPage = () => {
     updateMemberHistory,
     persistMembros: hookPersistMembros,
   } = useMemberManagement();
+
+  if (!authenticated) {
+    return (
+      <AdminPasswordDialog
+        isOpen={pwdOpen}
+        onOpenChange={setPwdOpen}
+        onSuccess={() => setPwdOpen(false)}
+      />
+    );
+  }
   
   // Removed schedule management hook and related state/functions
   // const scheduleManagement = useScheduleManagement({ membros, updateMemberHistory }); 

--- a/src/components/congregacao/AdminPasswordDialog.tsx
+++ b/src/components/congregacao/AdminPasswordDialog.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useAdminAuth } from '@/hooks/use-admin-auth';
+
+interface AdminPasswordDialogProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+}
+
+export function AdminPasswordDialog({ isOpen, onOpenChange, onSuccess }: AdminPasswordDialogProps) {
+  const { checkPassword } = useAdminAuth();
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(false);
+
+  const handleConfirm = () => {
+    if (checkPassword(password)) {
+      setPassword('');
+      setError(false);
+      onOpenChange(false);
+      onSuccess();
+    } else {
+      setError(true);
+    }
+  };
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Senha Administrativa</AlertDialogTitle>
+          <AlertDialogDescription>Digite a senha para continuar.</AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="space-y-2 py-2">
+          <Label htmlFor="adminPassword">Senha</Label>
+          <Input
+            id="adminPassword"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoFocus
+          />
+          {error && <p className="text-sm text-red-600">Senha incorreta</p>}
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancelar</AlertDialogCancel>
+          <AlertDialogAction onClick={handleConfirm}>Entrar</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/congregacao/AdminPasswordDialog.tsx
+++ b/src/components/congregacao/AdminPasswordDialog.tsx
@@ -26,8 +26,8 @@ export function AdminPasswordDialog({ isOpen, onOpenChange, onSuccess }: AdminPa
   const [password, setPassword] = useState('');
   const [error, setError] = useState(false);
 
-  const handleConfirm = () => {
-    if (checkPassword(password)) {
+  const handleConfirm = async () => {
+    if (await checkPassword(password)) {
       setPassword('');
       setError(false);
       onOpenChange(false);

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useAdminAuth } from '@/hooks/use-admin-auth';
+import { AdminPasswordDialog } from '@/components/congregacao/AdminPasswordDialog';
 import { cn } from '@/lib/utils';
 import { 
   Users, 
@@ -36,6 +39,16 @@ const menuItems = [
 
 export function Sidebar() {
   const pathname = usePathname();
+  const router = useRouter();
+  const { authenticated } = useAdminAuth();
+  const [pwdDialogOpen, setPwdDialogOpen] = useState(false);
+
+  const handleMembersClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (!authenticated) {
+      e.preventDefault();
+      setPwdDialogOpen(true);
+    }
+  };
 
   return (
     <div className="flex flex-col h-full bg-[#2B3A67] border-r border-[#2B3A67]">
@@ -45,10 +58,13 @@ export function Sidebar() {
       <nav className="flex-1 px-4 space-y-1">
         {menuItems.map((item) => {
           const isActive = pathname === item.href;
+          const handleClick =
+            item.href === '/congregacao/membros' ? handleMembersClick : undefined;
           return (
             <Link
               key={item.href}
               href={item.href}
+              onClick={handleClick}
               className={cn(
                 'flex items-center px-4 py-3 text-sm font-medium rounded-lg transition-colors',
                 isActive
@@ -62,6 +78,12 @@ export function Sidebar() {
           );
         })}
       </nav>
+      <AdminPasswordDialog
+        isOpen={pwdDialogOpen}
+        onOpenChange={setPwdDialogOpen}
+        onSuccess={() => router.push('/congregacao/membros')}
+      />
     </div>
   );
-} 
+}
+

--- a/src/hooks/use-admin-auth.ts
+++ b/src/hooks/use-admin-auth.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  carregarAdminPassword,
+  salvarAdminPassword,
+  carregarAdminAutenticado,
+  salvarAdminAutenticado,
+} from '@/lib/congregacao/storage';
+
+export function useAdminAuth() {
+  const [authenticated, setAuthenticated] = useState(false);
+
+  useEffect(() => {
+    setAuthenticated(carregarAdminAutenticado());
+  }, []);
+
+  const checkPassword = (pwd: string): boolean => {
+    const stored = carregarAdminPassword();
+    const ok = stored !== null && pwd === stored;
+    if (ok) {
+      salvarAdminAutenticado(true);
+      setAuthenticated(true);
+    }
+    return ok;
+  };
+
+  const setPassword = (pwd: string) => {
+    salvarAdminPassword(pwd);
+    salvarAdminAutenticado(true);
+    setAuthenticated(true);
+  };
+
+  const logout = () => {
+    salvarAdminAutenticado(false);
+    setAuthenticated(false);
+  };
+
+  return { authenticated, checkPassword, setPassword, logout };
+}

--- a/src/hooks/use-admin-auth.ts
+++ b/src/hooks/use-admin-auth.ts
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react';
 import {
   carregarAdminPassword,
   salvarAdminPassword,
+  carregarAdminPasswordFirestore,
+  salvarAdminPasswordFirestore,
   carregarAdminAutenticado,
   salvarAdminAutenticado,
 } from '@/lib/congregacao/storage';
@@ -15,8 +17,8 @@ export function useAdminAuth() {
     setAuthenticated(carregarAdminAutenticado());
   }, []);
 
-  const checkPassword = (pwd: string): boolean => {
-    const stored = carregarAdminPassword();
+  const checkPassword = async (pwd: string): Promise<boolean> => {
+    const stored = await carregarAdminPasswordFirestore();
     const ok = stored !== null && pwd === stored;
     if (ok) {
       salvarAdminAutenticado(true);
@@ -25,7 +27,8 @@ export function useAdminAuth() {
     return ok;
   };
 
-  const setPassword = (pwd: string) => {
+  const setPassword = async (pwd: string) => {
+    await salvarAdminPasswordFirestore(pwd);
     salvarAdminPassword(pwd);
     salvarAdminAutenticado(true);
     setAuthenticated(true);

--- a/src/lib/congregacao/constants.ts
+++ b/src/lib/congregacao/constants.ts
@@ -65,6 +65,8 @@ export const LOCAL_STORAGE_KEY_FIELD_SERVICE_MODALITIES = 'congregacao_field_ser
 export const LOCAL_STORAGE_KEY_FIELD_SERVICE_LOCATIONS = 'congregacao_field_service_locations';
 export const LOCAL_STORAGE_KEY_FIELD_SERVICE_TEMPLATE = 'congregacao_field_service_template';
 export const LOCAL_STORAGE_KEY_USER_SCHEDULE = 'congregacao_user_schedule';
+export const LOCAL_STORAGE_KEY_ADMIN_PASSWORD = 'congregacao_admin_password';
+export const LOCAL_STORAGE_KEY_ADMIN_AUTH = 'congregacao_admin_authenticated';
 
 
 export const BADGE_COLORS: Record<string, string> = {

--- a/src/lib/congregacao/storage.ts
+++ b/src/lib/congregacao/storage.ts
@@ -25,6 +25,8 @@ import {
   LOCAL_STORAGE_KEY_FIELD_SERVICE_LOCATIONS,
   LOCAL_STORAGE_KEY_FIELD_SERVICE_TEMPLATE,
   LOCAL_STORAGE_KEY_USER_SCHEDULE,
+  LOCAL_STORAGE_KEY_ADMIN_PASSWORD,
+  LOCAL_STORAGE_KEY_ADMIN_AUTH,
 } from './constants';
 import { validarEstruturaMembro } from './utils';
 import { collection, getDocs, setDoc, doc, deleteDoc, getDoc } from 'firebase/firestore';
@@ -477,4 +479,43 @@ export function salvarLocaisBase(items: ManagedListItem[]): void {
 export function limparLocaisBase(): void {
   if (typeof window === 'undefined') return;
   localStorage.removeItem(LOCAL_STORAGE_KEY_FIELD_SERVICE_LOCATIONS);
+}
+
+// --- Admin Authentication ---
+export function carregarAdminPassword(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return localStorage.getItem(LOCAL_STORAGE_KEY_ADMIN_PASSWORD);
+  } catch (error) {
+    console.error('Erro ao carregar senha admin:', error);
+    return null;
+  }
+}
+
+export function salvarAdminPassword(pwd: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(LOCAL_STORAGE_KEY_ADMIN_PASSWORD, pwd);
+  } catch (error) {
+    console.error('Erro ao salvar senha admin:', error);
+  }
+}
+
+export function carregarAdminAutenticado(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return localStorage.getItem(LOCAL_STORAGE_KEY_ADMIN_AUTH) === 'true';
+  } catch (error) {
+    console.error('Erro ao verificar autenticação admin:', error);
+    return false;
+  }
+}
+
+export function salvarAdminAutenticado(flag: boolean): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(LOCAL_STORAGE_KEY_ADMIN_AUTH, flag ? 'true' : 'false');
+  } catch (error) {
+    console.error('Erro ao definir autenticação admin:', error);
+  }
 }

--- a/src/lib/congregacao/storage.ts
+++ b/src/lib/congregacao/storage.ts
@@ -501,6 +501,17 @@ export function salvarAdminPassword(pwd: string): void {
   }
 }
 
+export async function carregarAdminPasswordFirestore(): Promise<string | null> {
+  const docRef = doc(collection(db, 'config'), 'admin');
+  const snapshot = await getDoc(docRef);
+  return snapshot.exists() ? (snapshot.data().password as string) : null;
+}
+
+export async function salvarAdminPasswordFirestore(pwd: string): Promise<void> {
+  const docRef = doc(collection(db, 'config'), 'admin');
+  await setDoc(docRef, { password: pwd });
+}
+
 export function carregarAdminAutenticado(): boolean {
   if (typeof window === 'undefined') return false;
   try {


### PR DESCRIPTION
## Summary
- store admin credentials in localStorage
- add helpers to read/write admin authentication
- implement `useAdminAuth` hook
- add admin password dialog component
- gate member management behind authentication and prompt in sidebar
- allow setting admin password in Configurações page
- document admin password usage in README

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684de78b9034833385c80f30c25769bb