### PR TITLE
Add per-table schedule generation

### DIFF
--- a/src/app/congregacao/designacoes/page.tsx
+++ b/src/app/congregacao/designacoes/page.tsx
@@ -79,8 +79,12 @@ export default function DesignacoesPage() {
       });
   }, []);
 
-  const handleScheduleGeneratedCallback = async (mes: number, ano: number) => {
-    const { success, error, generatedSchedule } = await scheduleManagement.generateNewSchedule(mes, ano);
+  const handleScheduleGeneratedCallback = async (
+    mes: number,
+    ano: number,
+    tabela: 'Indicadores' | 'Volantes' | 'AV'
+  ) => {
+    const { success, error, generatedSchedule } = await scheduleManagement.generateNewSchedule(mes, ano, tabela);
     if (success && generatedSchedule) {
       toast({ title: "Designações Geradas", description: `Cronograma para ${NOMES_MESES[mes]} de ${ano} gerado com sucesso.` });
     } else if (error) {

--- a/src/components/congregacao/ScheduleGenerationCard.tsx
+++ b/src/components/congregacao/ScheduleGenerationCard.tsx
@@ -25,7 +25,11 @@ interface AVSelectionContext {
 
 interface ScheduleGenerationCardProps {
   membros: Membro[];
-  onScheduleGenerated: (mes: number, ano: number) => Promise<{ success: boolean; error?: string; generatedSchedule?: DesignacoesFeitas }>;
+  onScheduleGenerated: (
+    mes: number,
+    ano: number,
+    tabela: 'Indicadores' | 'Volantes' | 'AV'
+  ) => Promise<{ success: boolean; error?: string; generatedSchedule?: DesignacoesFeitas }>;
   currentSchedule: DesignacoesFeitas | null;
   currentMes: number | null;
   currentAno: number | null;
@@ -158,12 +162,12 @@ export function ScheduleGenerationCard({
     return true;
   }, [currentSchedule, status, currentMes, currentAno]);
 
-  const handleGenerateSchedule = async () => {
+  const handleGenerateSchedule = async (tabela: 'Indicadores' | 'Volantes' | 'AV') => {
     setIsLoading(true);
     setError(null);
     try {
-      console.log('[DIAGNÓSTICO] Chamando onScheduleGenerated para mês:', selectedMes, 'ano:', selectedAno);
-      const result = await onScheduleGenerated(parseInt(selectedMes, 10), parseInt(selectedAno, 10));
+      console.log('[DIAGNÓSTICO] Chamando onScheduleGenerated para mês:', selectedMes, 'ano:', selectedAno, 'tabela:', tabela);
+      const result = await onScheduleGenerated(parseInt(selectedMes, 10), parseInt(selectedAno, 10), tabela);
       console.log('[DIAGNÓSTICO] Resultado de onScheduleGenerated:', result);
       if (result.success) {
         console.log('[DIAGNÓSTICO] Estado atualizado com schedule:', result.generatedSchedule);
@@ -257,14 +261,28 @@ export function ScheduleGenerationCard({
           >
             {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : 'Gerar PDF'}
           </Button>
-           <Button
-             onClick={handleGenerateSchedule}
-             disabled={isLoading || status === 'rascunho' || status === 'finalizado'}
-             className="w-full sm:w-auto"
-           >
-             {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : 'Gerar Cronograma (Indicadores/Volantes/AV)'}
-           </Button>
-           {/* New Clear Month Button */}
+          <Button
+            onClick={() => handleGenerateSchedule('Indicadores')}
+            disabled={isLoading || status === 'rascunho' || status === 'finalizado'}
+            className="w-full sm:w-auto"
+          >
+            {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : 'Gerar Indicadores'}
+          </Button>
+          <Button
+            onClick={() => handleGenerateSchedule('Volantes')}
+            disabled={isLoading || status === 'rascunho' || status === 'finalizado'}
+            className="w-full sm:w-auto"
+          >
+            {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : 'Gerar Volantes'}
+          </Button>
+          <Button
+            onClick={() => handleGenerateSchedule('AV')}
+            disabled={isLoading || status === 'rascunho' || status === 'finalizado'}
+            className="w-full sm:w-auto"
+          >
+            {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : 'Gerar AV'}
+          </Button>
+          {/* New Clear Month Button */}
            
         </div>
 

--- a/src/hooks/congregacao/useScheduleManagement.ts
+++ b/src/hooks/congregacao/useScheduleManagement.ts
@@ -55,15 +55,17 @@ export function useScheduleManagement({ membros, updateMemberHistory }: UseSched
   const internalUpdateMemberHistoryForMonth = useCallback((
     currentScheduleForMonth: DesignacoesFeitas,
     scheduleMes: number,
-    scheduleAno: number
+    scheduleAno: number,
+    tabela?: 'Indicadores' | 'Volantes' | 'AV'
   ) => {
+    const relevantFunctions = tabela ? FUNCOES_DESIGNADAS.filter(f => f.tabela === tabela).map(f => f.id) : FUNCOES_DESIGNADAS.filter(f => !f.id.startsWith("av") && !f.id.startsWith("limpeza")).map(f => f.id);
     const membrosComHistoricoAtualizado = [...membros].map(m => {
       const membroModificado = { ...m, historicoDesignacoes: { ...m.historicoDesignacoes } };
       Object.keys(membroModificado.historicoDesignacoes).forEach(histDateStr => {
         const histDateObj = new Date(histDateStr);
         if (histDateObj.getFullYear() === scheduleAno && histDateObj.getMonth() === scheduleMes) {
           const funcaoIdNoHistorico = membroModificado.historicoDesignacoes[histDateStr];
-          if (funcaoIdNoHistorico && !funcaoIdNoHistorico.startsWith('av') && !funcaoIdNoHistorico.startsWith('limpeza')) {
+          if (relevantFunctions.includes(funcaoIdNoHistorico)) {
              delete membroModificado.historicoDesignacoes[histDateStr];
           }
         }
@@ -73,7 +75,7 @@ export function useScheduleManagement({ membros, updateMemberHistory }: UseSched
         if (dataObj.getFullYear() === scheduleAno && dataObj.getMonth() === scheduleMes) {
           Object.entries(funcoesDoDia).forEach(([funcaoId, membroId]) => {
             if (membroId === m.id) {
-              if (!funcaoId.startsWith('av') && !funcaoId.startsWith('limpeza')) {
+              if (relevantFunctions.includes(funcaoId)) {
                 membroModificado.historicoDesignacoes[dateStr] = funcaoId;
               }
             }
@@ -86,16 +88,39 @@ export function useScheduleManagement({ membros, updateMemberHistory }: UseSched
   }, [membros, updateMemberHistory]);
 
 
-  const generateNewSchedule = useCallback(async (mes: number, ano: number): Promise<{ success: boolean; error?: string; generatedSchedule?: DesignacoesFeitas }> => {
-    const result = await calcularDesignacoesAction(mes, ano, membros);
+  const generateNewSchedule = useCallback(
+    async (
+      mes: number,
+      ano: number,
+      tabela: 'Indicadores' | 'Volantes' | 'AV'
+    ): Promise<{ success: boolean; error?: string; generatedSchedule?: DesignacoesFeitas }> => {
+    const result = await calcularDesignacoesAction(mes, ano, membros, tabela);
     if ('error' in result) {
       return { success: false, error: result.error };
     }
-    // Ao gerar novo, o status é 'rascunho'
-    persistScheduleToStateAndCache(result.designacoesFeitas, mes, ano, 'rascunho');
-    internalUpdateMemberHistoryForMonth(result.designacoesFeitas, mes, ano);
-    return { success: true, generatedSchedule: result.designacoesFeitas };
-  }, [membros, persistScheduleToStateAndCache, internalUpdateMemberHistoryForMonth]);
+
+    const newAssignments = result.designacoesFeitas;
+    const mergedSchedule: DesignacoesFeitas = scheduleState.designacoes && scheduleState.mes === mes && scheduleState.ano === ano
+      ? JSON.parse(JSON.stringify(scheduleState.designacoes))
+      : {};
+
+    const relevantFunctions = FUNCOES_DESIGNADAS.filter(f => f.tabela === tabela).map(f => f.id);
+    Object.entries(newAssignments).forEach(([dateStr, assignments]) => {
+      if (!mergedSchedule[dateStr]) mergedSchedule[dateStr] = { ...scheduleState.designacoes?.[dateStr] } as any;
+      Object.entries(assignments).forEach(([funcId, memberId]) => {
+        if (relevantFunctions.includes(funcId)) {
+          mergedSchedule[dateStr][funcId] = memberId;
+        }
+      });
+    });
+
+    persistScheduleToStateAndCache(mergedSchedule, mes, ano, 'rascunho');
+    if (tabela !== 'AV') {
+      internalUpdateMemberHistoryForMonth(newAssignments, mes, ano, tabela);
+    }
+
+    return { success: true, generatedSchedule: mergedSchedule };
+  }, [membros, scheduleState, persistScheduleToStateAndCache, internalUpdateMemberHistoryForMonth]);
 
   const confirmManualAssignmentOrSubstitution = useCallback((
     date: string,

--- a/src/lib/congregacao/assignment-logic.ts
+++ b/src/lib/congregacao/assignment-logic.ts
@@ -263,7 +263,8 @@ export async function sortMembersByPriority(
 export async function calcularDesignacoesAction(
   mes: number, // 0-11
   ano: number,
-  membros: Membro[] 
+  membros: Membro[],
+  tabela?: 'Indicadores' | 'Volantes' | 'AV'
 ): Promise<{ designacoesFeitas: DesignacoesFeitas } | { error: string }> {
   
   const DIAS_REUNIAO: DiasReuniao = DIAS_REUNIAO_CONFIG;
@@ -300,7 +301,9 @@ export async function calcularDesignacoesAction(
     const tipoReuniaoAtual = dataReuniao.getDay() === DIAS_REUNIAO.meioSemana ? 'meioSemana' : 'publica';
     
     const funcoesParaGeracaoAutomatica = FUNCOES_DESIGNADAS.filter(
-      f => f.tipoReuniao.includes(tipoReuniaoAtual)
+      f =>
+        f.tipoReuniao.includes(tipoReuniaoAtual) &&
+        (!tabela || f.tabela === tabela)
     );
     
     const dataReuniaoAnteriorObj = encontrarDataReuniaoAnterior(dataReuniao, tipoReuniaoAtual, datasDeReuniaoNoMes, DIAS_REUNIAO);


### PR DESCRIPTION
## Summary
- generate assignments per-table via new parameter in core logic
- update schedule management hook and card UI to use table-specific generation
- adjust designations page callback for new parameter

## Testing
- `npm run typecheck` *(fails: Cannot find module 'next', etc.)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfa1ac7748333b7246b2fcf19a845